### PR TITLE
modified delete queue track logic.

### DIFF
--- a/src/RendererProcess/components/LocalMusic/SidePane/QueTrack.vue
+++ b/src/RendererProcess/components/LocalMusic/SidePane/QueTrack.vue
@@ -9,7 +9,7 @@
     <p class="card_title">{{ track.defaultTitle }}</p>
     <p class="card_subTitle">{{ track.defaultArtist }}</p>
     <img
-      @click.stop="removeTrackFromCustomQueue(index)"
+      @click.stop="removeTrackFromCustomQueue(track)"
       src="@/RendererProcess/assets/images/x.svg"
     />
   </div>

--- a/src/RendererProcess/store/modules/LocalMusic/PlaybackManger.ts
+++ b/src/RendererProcess/store/modules/LocalMusic/PlaybackManger.ts
@@ -66,8 +66,8 @@ const mutations = {
         });
         state.customQueue = removeDuplicates(state.customQueue, "fileLocation");
     },
-    removeTrackFromCustomQueue(state: any, index: number) {
-        state.customQueue.splice(index, 1);
+    removeTrackFromCustomQueue(state: any, track:any) {
+        state.customQueue = state.customQueue.filter((x:any)=>{return x.fileLocation!== track.fileLocation})
     },
     clearCustomQueue(state: any) {
         state.customQueue = [];


### PR DESCRIPTION
currently in queue  track is deleted via index ,but when click on delete icon of queue  it sends one ,because of that it doesn't matter which track we delete from queue it always deletes first one.

But in changes i pass whole track and removes track that has fileLocation as  deleted track's fileLocation .